### PR TITLE
Support using Easymon::Testing methods directly or by mixin

### DIFF
--- a/lib/easymon/testing.rb
+++ b/lib/easymon/testing.rb
@@ -1,14 +1,16 @@
 module Easymon
-  class Testing
-    def self.stub_check(name)
+  module Testing
+    extend self
+
+    def stub_check(name)
       Easymon.const_get("#{name.to_s.capitalize}Check").any_instance.stubs(:check)
     end
 
-    def self.stub_service_success(name)
+    def stub_service_success(name)
       stub_check(name).returns([true, "Up"])
     end
 
-    def self.stub_service_failure(name)
+    def stub_service_failure(name)
       stub_check(name).returns([false, "Down"])
     end
   end


### PR DESCRIPTION
This branch makes the `Easymon::Testing` helper easier to use. It changes from a class to a module, and uses the `extend self` pattern to make its methods accessible either directly or by way of mixing in.

Call methods directly on the module:
```ruby
Easymon::Testing.stub_check(:redis)
```

Or mix into your tests for less typing:
```ruby
class MyTest < Minitest::Test
  include Easymon::Testing

  def test_something
    stub_check(:redis)
    # ...
  end
end
```