### PR TITLE
Shed the rest-client dependency in favor of using net/http

### DIFF
--- a/easymon.gemspec
+++ b/easymon.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rest-client", "~> 1.6"
   s.add_dependency "redis"
 
   s.add_development_dependency "rails", ['>= 3.0', '>= 4.0', '>= 2.3.18']

--- a/lib/easymon/checks/http_check.rb
+++ b/lib/easymon/checks/http_check.rb
@@ -1,4 +1,4 @@
-require "restclient"
+require 'net/https'
 
 module Easymon
   class HttpCheck
@@ -19,15 +19,22 @@ module Easymon
     end
     
     private
-      def http_up?(config_url)
-        response = RestClient::Request.execute(
-                                      :method => :head, 
-                                      :url => config_url,
-                                      :timeout => 5,
-                                      :open_timeout => 5)
-        true
+      def http_up?(url)
+        http_head(url).is_a?(Net::HTTPSuccess)
       rescue Exception
         false
+      end
+
+      def http_head(url)
+        uri = URI.parse(url)
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.is_a?(URI::HTTPS)
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        http.open_timeout = 5
+        http.read_timeout = 5
+
+        http.request Net::HTTP::Head.new(uri.request_uri)
       end
   end
 end

--- a/test/unit/checks/http_check_test.rb
+++ b/test/unit/checks/http_check_test.rb
@@ -1,21 +1,32 @@
 require 'test_helper'
 
 class HttpCheckTest < ActiveSupport::TestCase
-  
   test "#run sets success conditions on successful run" do
-    RestClient::Request.any_instance.stubs(:execute).returns(true)
+    Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPSuccess.new(1.1, 200, "OK"))
+
     check = create_check
     results = check.check
-    
+
     assert_equal("Up", results[1])
     assert_equal(true, results[0])
   end
   
   test "#run sets failure conditions on a failed run" do
-    RestClient::Request.any_instance.stubs(:execute).raises("boom")
+    Net::HTTP.any_instance.stubs(:request).returns(Net::HTTPNotFound.new(1.1, 404, "Not Found"))
+
     check = create_check
     results = check.check
-    
+
+    assert_equal("Down", results[1])
+    assert_equal(false, results[0])
+  end
+
+  test "#run sets failure conditions on an errored run" do
+    Net::HTTP.any_instance.stubs(:request).raises("boom")
+
+    check = create_check
+    results = check.check
+
     assert_equal("Down", results[1])
     assert_equal(false, results[0])
   end
@@ -26,8 +37,7 @@ class HttpCheckTest < ActiveSupport::TestCase
     assert_equal("Down", results[1])
     assert_equal(false, results[0])
   end
-  
-  
+
   private
   def create_check
     # Fake URL


### PR DESCRIPTION
Replaces `rest-client` with its stdlib `net/http` equivalent. Since we're only making HEAD requests, there's little need to haul in rest-client. The fewer dependencies the better.

Note that this tightens up the HTTP check to require a 2xx response. Previously a 3xx response would be followed by `rest-client` – there's no support for following redirects here.

Obviates the need for #12.