### PR TITLE
Rails 3.0.20

### DIFF
--- a/lib/easymon.rb
+++ b/lib/easymon.rb
@@ -50,8 +50,8 @@ module Easymon
     elsif Easymon.rails30?
       # Greater than 3.0, but less than 3.1
       mapper.instance_eval do
-        get "#{path}(.:format)" => 'easymon/checks#index'
-        get "#{path}/:check" => 'easymon/checks#show'
+        get "#{path}(.:format)", :controller => 'easymon/checks', :action => 'index'
+        get "#{path}/:check", :controller => 'easymon/checks', :action => 'show'
       end
     elsif Easymon.mountable_engine?
       # Rails 3.1+

--- a/lib/easymon.rb
+++ b/lib/easymon.rb
@@ -62,7 +62,7 @@ module Easymon
       end
     end
   end
-  
+
   def self.timing_to_ms(timing = 0)
     sprintf("%.3f", (timing * 1000))
   end


### PR DESCRIPTION
I had to update the routing for the "Greater than 3.0, but less than 3.1" branch of routes, the 3.0.20 rails app I tested this on had routing errors with the removed route format.

Tests still pass, but I guess that's because we're using a rails 4.x app to test with. Adding a 3.0.x app also seems excessive.