### PR TITLE
Backwards compatible "Deprecation Warning" cleanup for rails5

### DIFF
--- a/app/controllers/easymon/checks_controller.rb
+++ b/app/controllers/easymon/checks_controller.rb
@@ -5,8 +5,8 @@ module Easymon
   class ChecksController < ApplicationController
     rescue_from Easymon::NoSuchCheck do |e|
       respond_to do |format|
-         format.any(:text, :html) { render :text => e.message, :status => :not_found }
-         format.json { render :json => e.message, :status => :not_found }
+        format.any(:text, :html) { render_result e.message, :not_found }
+        format.json { render :json => e.message, :status => :not_found }
       end
     end
 
@@ -32,7 +32,7 @@ module Easymon
       end
 
       respond_to do |format|
-         format.any(:text, :html) { render :text => message, :status => response_status }
+         format.any(:text, :html) { render_result message, response_status }
          format.json { render :json => checklist, :status => response_status }
       end
     end
@@ -55,14 +55,12 @@ module Easymon
         result = Easymon::Result.new(check_result, timing, check[:critical])
       end
 
-
-
       respond_to do |format|
         format.any(:text, :html) do
           if is_critical
-            render :text => add_prefix(checklist.success?, checklist), :status => checklist.response_status
+            render_result add_prefix(checklist.success?, checklist), checklist.response_status
           else
-            render :text => result, :status => result.response_status
+            render_result result, result.response_status
           end
         end
         format.json do
@@ -76,6 +74,11 @@ module Easymon
     end
 
     private
+      def render_result(message, status)
+        symbol_for_plain = Easymon.has_render_plain? ? :plain : :text
+        render symbol_for_plain => message, :status => status
+      end
+
       def add_prefix(result, message)
         result ? "OK #{message}" : "DOWN #{message}"
       end

--- a/lib/easymon.rb
+++ b/lib/easymon.rb
@@ -35,6 +35,15 @@ module Easymon
     Easymon.rails_version > Gem::Version.new("3.1")
   end
 
+  def self.newer_than?(version)
+    Easymon.rails_version > Gem::Version.new(version)
+  end
+
+  def self.has_render_plain?
+    # Rails 4.1.0 introduced :plain, Rails 5 deprecated :text
+    Easymon.newer_than?("4.1.0.beta")
+  end
+
   def self.routes(mapper, path = "/up")
     if Easymon.rails2?
       # Rails 2.3.x (anything less than 3, really)


### PR DESCRIPTION
Rails 5 deprecates `render :text` in favor of `render :plain`.  However, since it was only introduced in 4.1.0, we can't do a blanket change. This introduces some sugar methods to handle feature definitions as long as we can peg them to a version.