### PR TITLE
Speed up DB checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ the availability of your main database.  It's usually invoked as such:
 Easymon::ActiveRecordCheck.new(ActiveRecord::Base)
 ````
 
-Internally, it compares `1 == klass.connection.select_value("SELECT 1").to_i`
-where klass is whatever class you passed to the check.  Usually this will be
-ActiveRecord::Base, but feel free to go crazy.
+Internally, it checks `klass.connection.active?` where klass is whatever class
+you passed to the check.  Usually this will be ActiveRecord::Base, but feel free
+to go crazy.
 
 ### Redis
 `Easymon::RedisCheck` will check the availability of a Redis server, given an

--- a/lib/easymon/checks/active_record_check.rb
+++ b/lib/easymon/checks/active_record_check.rb
@@ -18,7 +18,7 @@ module Easymon
     
     private
       def database_up?
-        1 == klass.connection.select_value("SELECT 1").to_i
+        klass.connection.active?
       rescue
         false
       end

--- a/lib/easymon/checks/split_active_record_check.rb
+++ b/lib/easymon/checks/split_active_record_check.rb
@@ -47,7 +47,7 @@ module Easymon
     
     private
       def database_up?(connection)
-          1 == connection.select_value("SELECT 1").to_i
+        connection.active?
       rescue
         false
       end

--- a/test/controllers/easymon/checks_controller_test.rb
+++ b/test/controllers/easymon/checks_controller_test.rb
@@ -33,7 +33,7 @@ module Easymon
 
     test "index when a critical check fails" do
       Easymon::Repository.add("database", Easymon::ActiveRecordCheck.new(ActiveRecord::Base), :critical)
-      ActiveRecord::Base.connection.stubs(:select_value).raises("boom")
+      ActiveRecord::Base.connection.stubs(:active?).raises("boom")
       get :index
       assert_response :service_unavailable
       assert response.body.include?("database: Down"), "Should include failure text, got #{response.body}"
@@ -78,7 +78,7 @@ module Easymon
 
     test "show when the check fails" do
       Easymon::Repository.add("database", Easymon::ActiveRecordCheck.new(ActiveRecord::Base))
-      ActiveRecord::Base.connection.stubs(:select_value).raises("boom")
+      ActiveRecord::Base.connection.stubs(:active?).raises("boom")
 
       get :show, :check => "database"
 

--- a/test/unit/checks/active_record_check_on_postgresql_test.rb
+++ b/test/unit/checks/active_record_check_on_postgresql_test.rb
@@ -11,7 +11,7 @@ class ActiveRecordCheckOnPostgresqlTest < ActiveSupport::TestCase
   end
 
   test "#check returns a failed result on a failed run" do
-    PGBase.connection.stubs(:select_value).raises("boom")
+    PGBase.connection.stubs(:active?).raises("boom")
     check = create_check
     results = check.check
 

--- a/test/unit/checks/active_record_check_test.rb
+++ b/test/unit/checks/active_record_check_test.rb
@@ -1,31 +1,31 @@
 require 'test_helper'
 
 class ActiveRecordCheckTest < ActiveSupport::TestCase
-  
+
   test "#check returns a successful result on a good run" do
     check = create_check
     results = check.check
-    
+
     assert_equal(true, results[0])
     assert_equal("Up", results[1])
   end
-  
+
   test "#check returns a failed result on a failed run" do
-    ActiveRecord::Base.connection.stubs(:select_value).raises("boom")
+    ActiveRecord::Base.connection.stubs(:active?).raises("boom")
     check = create_check
     results = check.check
-    
+
     assert_equal(false, results[0])
     assert_equal("Down", results[1])
   end
-  
+
   test "given nil as a config" do
     check = Easymon::ActiveRecordCheck.new(nil)
     results = check.check
     assert_equal("Down", results[1])
     assert_equal(false, results[0])
   end
-  
+
   private
   def create_check
     Easymon::ActiveRecordCheck.new(ActiveRecord::Base)

--- a/test/unit/checks/split_active_record_check_test.rb
+++ b/test/unit/checks/split_active_record_check_test.rb
@@ -1,48 +1,48 @@
 require 'test_helper'
 
 class SplitActiveRecordCheckTest < ActiveSupport::TestCase
-  
+
   test "#run sets success conditions on successful run" do
     master = ActiveRecord::Base.connection
     Easymon::Base.establish_connection
     slave = Easymon::Base.connection
-    
+
     check = Easymon::SplitActiveRecordCheck.new { [master, slave] }
-    
+
     results = check.check
-    
+
     assert_equal("Master: Up - Slave: Up", results[1])
     assert_equal(true, results[0])
   end
-  
+
   test "#run sets failed conditions when slave is down" do
     master = ActiveRecord::Base.connection
     Easymon::Base.establish_connection
     slave = Easymon::Base.connection
 
-    slave.stubs(:select_value).raises("boom")
-    
+    slave.stubs(:active?).raises("boom")
+
     check = Easymon::SplitActiveRecordCheck.new { [master, slave] }
     results = check.check
 
     assert_equal("Master: Up - Slave: Down", results[1])
     assert_equal(false, results[0])
   end
-  
+
   test "#run sets failed conditions when master is down" do
     master = ActiveRecord::Base.connection
     Easymon::Base.establish_connection
     slave = Easymon::Base.connection
 
-    master.stubs(:select_value).raises("boom")
-    
+    master.stubs(:active?).raises("boom")
+
     check = Easymon::SplitActiveRecordCheck.new { [master, slave] }
     results = check.check
-    
+
     assert_equal("Master: Down - Slave: Up", results[1])
     assert_equal(false, results[0])
   end
-  
+
   test "given nil as a config" do
     check = Easymon::SplitActiveRecordCheck.new { }
     results = check.check
@@ -61,7 +61,7 @@ module Easymon
         super config
       end
     end
-    
+
     def database_configuration
       env = "#{Rails.env}_slave"
       config = YAML.load_file(Rails.root.join('config/database.yml'))[env]


### PR DESCRIPTION
User their optimized `connection.active?` instead of a full SELECT
query, skipping extra client & server overhead on AR adapters that offer
a faster path.

The mysql2 adapter, for example, uses a connection PING command to check
connection liveness. I measured ~0.39ms to SELECT and ~0.07ms to PING on
a typical production host.