### PR TITLE
Make RedisCheck compatible with redis-rb:4.0

### DIFF
--- a/lib/easymon/checks/redis_check.rb
+++ b/lib/easymon/checks/redis_check.rb
@@ -22,7 +22,7 @@ module Easymon
       def redis_up?
         redis = Redis.new(@config)
         reply = redis.ping == 'PONG'
-        redis.client.disconnect
+        redis.close
         reply
       rescue
         false


### PR DESCRIPTION
redis-rb quietly [removed the `#client` method](https://github.com/redis/redis-rb/commit/31385074b6bbeef7e1f9849b0b1149b9ef870e2d#diff-54fab56a3b12825ac3ed9243b67fd459) used in `RedisCheck` to close the connection.
The preferred way is using the `#close` method.