### PR TITLE
Remove unescaped check name from not-found output

### DIFF
--- a/app/controllers/easymon/checks_controller.rb
+++ b/app/controllers/easymon/checks_controller.rb
@@ -17,8 +17,8 @@ module Easymon
 
     rescue_from Easymon::NoSuchCheck do |e|
       respond_to do |format|
-        format.any(:text, :html) { render_result e.message, :not_found }
-        format.json { render :json => e.message, :status => :not_found }
+        format.any(:text, :html) { render_result "Check Not Found", :not_found }
+        format.json { render :json => "Check Not Found", :status => :not_found }
       end
     end
 

--- a/lib/easymon/version.rb
+++ b/lib/easymon/version.rb
@@ -1,3 +1,3 @@
 module Easymon
-  VERSION = "1.4"
+  VERSION = "1.5"
 end

--- a/lib/easymon/version.rb
+++ b/lib/easymon/version.rb
@@ -1,3 +1,3 @@
 module Easymon
-  VERSION = "1.5"
+  VERSION = "1.4.1"
 end


### PR DESCRIPTION
This fixes #26, where the check name could be used to execute a reflected XSS attack.