### PR TITLE
Use Primary-Replica terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ module Easymon
       end
     end
     def database_configuration
-      env = "#{Rails.env}_slave"
+      env = "#{Rails.env}_replica"
       config = YAML.load_file(Rails.root.join('config/database.yml'))[env]
     end
   end

--- a/lib/easymon/checks/split_active_record_check.rb
+++ b/lib/easymon/checks/split_active_record_check.rb
@@ -2,10 +2,10 @@ module Easymon
   class SplitActiveRecordCheck
     attr_accessor :block
     attr_accessor :results
-    
+
     # Here we pass a block so we get a fresh instance of ActiveRecord::Base or
     # whatever other class we might be using to make database connections
-    # 
+    #
     # For example, given the following other class:
     # module Easymon
     #   class Base < ActiveRecord::Base
@@ -18,12 +18,12 @@ module Easymon
     #     end
     #
     #     def database_configuration
-    #       env = "#{Rails.env}_slave"
+    #       env = "#{Rails.env}_replica"
     #       config = YAML.load_file(Rails.root.join('config/database.yml'))[env]
     #     end
     #   end
     # end
-    # 
+    #
     # We would check both it and ActiveRecord::Base like so:
     # check = Easymon::SplitActiveRecordCheck.new {
     #   [ActiveRecord::Base.connection, Easymon::Base.connection] 
@@ -31,20 +31,20 @@ module Easymon
     # Easymon::Repository.add("split-database", check)
     def initialize(&block)
       self.block = block
-    end 
-    
+    end
+
     # Assumes only 2 connections
     def check
       connections = Array(@block.call)
 
       results = connections.map{|connection| database_up?(connection) }
-      
-      master_status = results.first ? "Master: Up" : "Master: Down"
-      slave_status = results.last ? "Slave: Up" : "Slave: Down"
-      
-      [(results.all? && results.count > 0), "#{master_status} - #{slave_status}"]
+
+      primary_status = results.first ? "Primary: Up" : "Primary: Down"
+      replica_status = results.last ? "Replica: Up" : "Replica: Down"
+
+      [(results.all? && results.count > 0), "#{primary_status} - #{replica_status}"]
     end
-    
+
     private
       def database_up?(connection)
         connection.active?

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -17,10 +17,10 @@ test:
   host: 127.0.0.1
   port: 3306
 
-test_slave:
+test_replica:
   adapter: mysql2
   encoding: utf8
-  database: dummy_test_slave
+  database: dummy_test_replica
   username: root
   host: 127.0.0.1
   port: 3306


### PR DESCRIPTION
I was reading HEY's Gemfile and come across this gem and noticed the
slave word while reading the README file. It may be good to move away
from the master-slave terminology given recent events. It is only used
internally and doesn't require any changes for users of this gem.
