### PR TITLE
Fix writeable check compatibility

### DIFF
--- a/lib/easymon/checks/active_record_mysql_writeable_check.rb
+++ b/lib/easymon/checks/active_record_mysql_writeable_check.rb
@@ -21,7 +21,7 @@ module Easymon
 
     private
       def database_writeable?
-        klass.connection.execute(@query).entries.flatten.first == 0
+        klass.connection.execute(@query).to_enum.first.first.to_i == 0
       rescue
         false
       end

--- a/lib/easymon/checks/active_record_mysql_writeable_check.rb
+++ b/lib/easymon/checks/active_record_mysql_writeable_check.rb
@@ -2,11 +2,9 @@ module Easymon
   class ActiveRecordMysqlWriteableCheck
     attr_accessor :klass
 
-    def initialize(klass, makara = false)
+    def initialize(klass)
       self.klass = klass
-      @query = "SELECT @@read_only"
-      # Trick makara into using the primary db
-      @query += " for UPDATE" if makara
+      @query = "SELECT @@read_only for UPDATE"
     end
 
     def check

--- a/lib/easymon/version.rb
+++ b/lib/easymon/version.rb
@@ -1,3 +1,3 @@
 module Easymon
-    VERSION = "1.6.1"
+    VERSION = "1.6.2"
 end


### PR DESCRIPTION
The `mysql` gem doesn't like the code we used for checking the result set!

```
> ActiveRecord::Base.connection.execute("SELECT @@read_only").entries.flatten.first
NoMethodError: undefined method `entries' for #<Mysql::Result:0x00557ae31ec7e8>
	from (irb):1
	from /app/shared/bundle/ruby/1.9.1/bundler/gems/rails-857c6ee62c05/railties/lib/rails/commands/console.rb:44:in `start'
	from /app/shared/bundle/ruby/1.9.1/bundler/gems/rails-857c6ee62c05/railties/lib/rails/commands/console.rb:8:in `start'
	from /app/shared/bundle/ruby/1.9.1/bundler/gems/rails-857c6ee62c05/railties/lib/rails/commands.rb:23:in `<top (required)>'
	from script/rails:6:in `require'
	from script/rails:6:in `<main>'
```
This will update the `active_record_mysql_writeable_check.rb` to use syntax that works for both mysql adapters.