### PR TITLE
SSL configuration and authentication for the HTTP check

### DIFF
--- a/lib/easymon/checks/http_check.rb
+++ b/lib/easymon/checks/http_check.rb
@@ -3,11 +3,11 @@ require 'net/https'
 module Easymon
   class HttpCheck
     attr_accessor :url
-    
+
     def initialize(url)
       self.url = url
-    end 
-    
+    end
+
     def check
       check_status = http_up?(url)
       if check_status
@@ -17,7 +17,7 @@ module Easymon
       end
       [check_status, message]
     end
-    
+
     private
       def http_up?(url)
         http_head(url).is_a?(Net::HTTPSuccess)
@@ -27,10 +27,11 @@ module Easymon
 
       def http_head(url)
         uri = URI.parse(url)
+        is_https = uri.is_a?(URI::HTTPS)
 
         http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = uri.is_a?(URI::HTTPS)
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        http.use_ssl = is_https
+        http.verify_mode = is_https ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
         http.open_timeout = 5
         http.read_timeout = 5
 

--- a/lib/easymon/checks/http_check.rb
+++ b/lib/easymon/checks/http_check.rb
@@ -35,7 +35,10 @@ module Easymon
         http.open_timeout = 5
         http.read_timeout = 5
 
-        http.request Net::HTTP::Head.new(uri.request_uri)
+        head = Net::HTTP::Head.new(uri.request_uri)
+        head.basic_auth(uri.user, uri.password) unless uri.userinfo.nil?
+
+        http.request head
       end
   end
 end

--- a/test/unit/checks/http_check_test.rb
+++ b/test/unit/checks/http_check_test.rb
@@ -38,6 +38,16 @@ class HttpCheckTest < ActiveSupport::TestCase
     assert_equal(false, results[0])
   end
 
+  test "uses the right ssl configuration" do
+    Net::HTTP.any_instance.expects(:use_ssl=).with(true)
+    Net::HTTP.any_instance.expects(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
+    Easymon::HttpCheck.new("https://localhost:9200").check
+
+    Net::HTTP.any_instance.expects(:use_ssl=).with(false)
+    Net::HTTP.any_instance.expects(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
+    Easymon::HttpCheck.new("http://localhost:9200").check
+  end
+
   private
   def create_check
     # Fake URL

--- a/test/unit/checks/http_check_test.rb
+++ b/test/unit/checks/http_check_test.rb
@@ -48,6 +48,14 @@ class HttpCheckTest < ActiveSupport::TestCase
     Easymon::HttpCheck.new("http://localhost:9200").check
   end
 
+  test "sends request with basic auth if present" do
+    Net::HTTP::Head.any_instance.expects(:basic_auth).with("user", "password")
+    Easymon::HttpCheck.new("https://user:password@localhost:9200").check
+
+    Net::HTTP::Head.any_instance.expects(:basic_auth).never
+    Easymon::HttpCheck.new("https://localhost:9200").check
+  end
+
   private
   def create_check
     # Fake URL


### PR DESCRIPTION
While implementing some HTTP status checks that we use in one of our applications, I noticed that the HTTP check [skips SSL certificate validation](https://github.com/basecamp/easymon/blob/9c3a63193bca9de4b7c5488a600de51995643060/lib/easymon/checks/http_check.rb#L33) in HTTPS requests, and that it does not use the authorization credentials if provided in the URI, which required us to monkey-patch it so we can use it.

This PR fixes both of those things.
- Verify the SSL certificate on HTTP requests
- Add basic authentication to the request, if it's present in the URI

Let me know if you need me to change anything in order to get it merged!