### PR TITLE
Fix ActiveRecord check

### DIFF
--- a/lib/easymon/checks/active_record_check.rb
+++ b/lib/easymon/checks/active_record_check.rb
@@ -18,6 +18,7 @@ module Easymon
     
     private
       def database_up?
+        klass.connection.connect!
         klass.connection.active?
       rescue
         false


### PR DESCRIPTION
In Rails 7.1 the database connection is no longer triggered by #new_connection, this implies that at boot time the connection is not yet active. To fix it first trigger a connection ourselves.

See https://github.com/rails/rails/commit/2da1852ac9b1886407464b246da3b99cfa186cfc