### PR TITLE
Wrap initializer example in configuration hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ To get started, you'll need to add an initializer for this to do anything.
 In `config/initializers/easymon.rb`:
 
 ````ruby
-Easymon::Repository.add("application-database", Easymon::ActiveRecordCheck.new(ActiveRecord::Base))
+Rails.application.config.after_initialize do
+  Easymon::Repository.add("application-database", Easymon::ActiveRecordCheck.new(ActiveRecord::Base))
+end
 ````
 
 This will register a check called `application-database` for use.


### PR DESCRIPTION
Directly calling `ActiveRecord::Base` in an initializer will [prematurely ](https://guides.rubyonrails.org/engines.html#avoid-loading-rails-frameworks)load `ActiveRecord::Base`. This can be avoided by wrapping it in a configuration hook.
