### PR TITLE
Add a health check for multiple databases

### DIFF
--- a/lib/easymon.rb
+++ b/lib/easymon.rb
@@ -9,6 +9,7 @@ require "easymon/result"
 
 require "easymon/checks/active_record_check"
 require "easymon/checks/active_record_mysql_writeable_check"
+require "easymon/checks/multi_active_record_check"
 require "easymon/checks/split_active_record_check"
 require "easymon/checks/redis_check"
 require "easymon/checks/redis_writeable_check"

--- a/lib/easymon/checks/multi_active_record_check.rb
+++ b/lib/easymon/checks/multi_active_record_check.rb
@@ -1,0 +1,52 @@
+module Easymon
+  class MultiActiveRecordCheck
+    attr_accessor :block
+    attr_accessor :results
+
+    # Here we pass a block so we get a fresh instance of ActiveRecord::Base or
+    # whatever other class we might be using to make database connections
+    #
+    # For example, given the following other class:
+    # module Easymon
+    #   class PrimaryReplica < ActiveRecord::Base
+    #     establish_connection :"primary_replica"
+    #   end
+    #
+    #   class OtherReplica < ActiveRecord::Base
+    #     establish_connection :"other_replica"
+    #   end
+    # end
+    #
+    # We would check both it and ActiveRecord::Base like so:
+    # check = Easymon::MultiActiveRecordCheck.new {
+    #    {
+    #      "Primary": ActiveRecord::Base.connection,
+    #      "PrimaryReplica": Easymon::PrimaryReplica.connection
+    #      "OtherReplica": Easymon::OtherReplica.connection
+    #    }
+    # }
+    # Easymon::Repository.add("multi-database", check)
+
+    def initialize(&block)
+      self.block = block
+    end
+
+    def check
+      connections = Hash(@block.call)
+
+      results = connections.transform_values { |connection| database_up?(connection) }
+
+      status = results.map { |db_name, result| "#{db_name}: #{result ? 'Up' : 'Down'}" }.join(" - ")
+
+      [ (results.any? && results.values.all?), status ]
+    end
+
+    private
+      def database_up?(connection)
+        connection.connect!
+        connection.active?
+      rescue
+        false
+      end
+  end
+end

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -27,6 +27,15 @@ test:
     port: 3306
     replica: true
 
+  other_replica:
+    adapter: mysql2
+    encoding: utf8
+    database: dummy_test
+    username: root
+    host: 127.0.0.1
+    port: 3306
+    replica: true
+
 test_replica:
   adapter: mysql2
   encoding: utf8

--- a/test/unit/checks/multi_active_record_check_test.rb
+++ b/test/unit/checks/multi_active_record_check_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+
+class MultiActiveRecordCheckTest < ActiveSupport::TestCase
+  test "#run sets success conditions on successful run" do
+    primary = ActiveRecord::Base.connection
+    primary_replica = Easymon::PrimaryReplica.connection
+    other_replica = Easymon::OtherReplica.connection
+
+    check = Easymon::MultiActiveRecordCheck.new do
+      {
+        "Primary": primary, "PrimaryReplica": primary_replica, "OtherReplica": other_replica
+      }
+    end
+    results = check.check
+
+    assert_equal("Primary: Up - PrimaryReplica: Up - OtherReplica: Up", results[1])
+    assert_equal(true, results[0])
+  end
+
+  test "#run sets failed conditions when replica is down" do
+    primary = ActiveRecord::Base.connection
+    primary_replica = Easymon::PrimaryReplica.connection
+    other_replica = Easymon::OtherReplica.connection
+
+    primary_replica.stubs(:active?).raises("boom")
+
+    check = Easymon::MultiActiveRecordCheck.new do
+      {
+        "Primary": primary, "PrimaryReplica": primary_replica, "OtherReplica": other_replica
+      }
+    end
+    results = check.check
+
+    assert_equal("Primary: Up - PrimaryReplica: Down - OtherReplica: Up", results[1])
+    assert_equal(false, results[0])
+  end
+
+  test "#run sets failed conditions when primary is down" do
+    primary = ActiveRecord::Base.connection
+    primary_replica = Easymon::PrimaryReplica.connection
+    other_replica = Easymon::OtherReplica.connection
+
+    primary.stubs(:active?).raises("boom")
+
+    check = Easymon::MultiActiveRecordCheck.new do
+      {
+        "Primary": primary, "PrimaryReplica": primary_replica, "OtherReplica": other_replica
+      }
+    end
+    results = check.check
+
+    assert_equal("Primary: Down - PrimaryReplica: Up - OtherReplica: Up", results[1])
+    assert_equal(false, results[0])
+  end
+
+  test "given nil as a config" do
+    check = Easymon::MultiActiveRecordCheck.new { }
+    results = check.check
+    assert_equal("", results[1])
+    assert_equal(false, results[0])
+  end
+end
+
+# This would be done in the host app
+module Easymon
+  class PrimaryReplica < ActiveRecord::Base
+    establish_connection :primary_replica
+  end
+
+  class OtherReplica < ActiveRecord::Base
+    establish_connection :other_replica
+  end
+end


### PR DESCRIPTION
Support a new type of health check for multiple databases rather than SplitActiveRecordCheck which only handles a primary and replica.

Tests pass fine.