### PR TITLE
Add `benchmark` as dependency for compatibility with Ruby 3.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    easymon (1.6.3)
+    easymon (1.6.4)
       benchmark
       redis
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ PATH
   remote: .
   specs:
     easymon (1.6.3)
+      benchmark
       redis
 
 GEM

--- a/easymon.gemspec
+++ b/easymon.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "redis"
+  s.add_dependency "benchmark"
 
   s.add_development_dependency "rails", [ '>= 3.0', '>= 4.0', '>= 2.3.18' ]
   s.add_development_dependency "mysql2", "~> 0.5"

--- a/lib/easymon/version.rb
+++ b/lib/easymon/version.rb
@@ -1,3 +1,3 @@
 module Easymon
-    VERSION = "1.6.3"
+    VERSION = "1.6.4"
 end


### PR DESCRIPTION
```
benchmark was loaded from the standard library, but
will no longer be part of the default gems starting
from Ruby 3.5.0. You can add benchmark to your Gemfile
or gemspec to silence this warning.
Also please contact the author of easymon-1.6.3 to request
adding benchmark into its gemspec.
```